### PR TITLE
Fixing lazyPath error for latest zig master

### DIFF
--- a/zigglgen-example/build.zig
+++ b/zigglgen-example/build.zig
@@ -14,7 +14,7 @@ pub fn build(b: *std.Build) void {
 
     const exe = b.addExecutable(.{
         .name = "zigglgen-example",
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b_path(b, "main.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -28,7 +28,7 @@ pub fn build(b: *std.Build) void {
     if (use_gles) {
         // Use the vendored OpenGL ES 3.0 bindings.
         exe.root_module.addAnonymousImport("gl", .{
-            .root_source_file = .{ .path = "gles3.zig" },
+            .root_source_file = b_path(b, "gles3.zig"),
         });
     } else {
         // Generate OpenGL 4.1 bindings at build time.
@@ -58,4 +58,12 @@ pub fn build(b: *std.Build) void {
 
     const update_gles = b.step("update-gles-bindings", "Update 'gles3.zig'");
     update_gles.dependOn(&copy_gles.step);
+}
+
+// TODO 2024.5.0-mach: Replace with 'b.path'.
+fn b_path(b: *std.Build, sub_path: []const u8) std.Build.LazyPath {
+    return if (@hasDecl(std.Build, "path"))
+        b.path(sub_path)
+    else
+        .{ .path = sub_path };
 }

--- a/zigglgen/build.zig
+++ b/zigglgen/build.zig
@@ -6,7 +6,7 @@ pub fn build(b: *std.Build) void {
 
     const generator = b.addExecutable(.{
         .name = "zigglgen-generator",
-        .root_source_file = .{ .path = "generator.zig" },
+        .root_source_file = b_path(b, "generator.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -61,4 +61,12 @@ fn thisDependency(b: *std.Build, args: anytype) *std.Build.Dependency {
         return b.dependency(dep_name, args);
     }
     std.debug.panic("zigglgen is not a dependency in '{s}'", .{b.pathFromRoot("build.zig.zon")});
+}
+
+// TODO 2024.5.0-mach: Replace with 'b.path'.
+fn b_path(b: *std.Build, sub_path: []const u8) std.Build.LazyPath {
+    return if (@hasDecl(std.Build, "path"))
+        b.path(sub_path)
+    else
+        .{ .path = sub_path };
 }


### PR DESCRIPTION
Hello!

Attempted to use this earlier and noticed that on the zig master branch it wouldn't compile, complaining about .path not being part of lazyPath (I would assume this was removed in a commit recently).

This is all it takes to fix it, and as far as I know this works on stable as well, but can't confirm as I don't use stable.

Let me know if there's any issues and I'll take a look.

Thank you!