### PR TITLE
Make zigglgen compatible with Zig master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-zig-cache/
+.zig-cache/
 zig-out/

--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@ The only Zig OpenGL binding generator you need.
 
 ## Installation and usage
 
-zigglgen officially supports the following versions of the Zig compiler:
+This version of zigglgen officially supports the following versions of the Zig compiler:
 
-- `0.12.0-dev.3180+83e578a18`/[`2024.3.0-mach`](https://machengine.org/about/nominated-zig/#202410-mach)
-- `0.12.0`
-- master (last tested with `0.13.0-dev.230+50a141945`)
+- master (last tested with `0.14.0-dev.1671+085cc54aa`)
 
 Older or more recent versions of the compiler are not guaranteed to be compatible.
 

--- a/zigglgen-example/build.zig
+++ b/zigglgen-example/build.zig
@@ -50,7 +50,7 @@ pub fn build(b: *std.Build) void {
 
     // Set up a maintenance task step for updating the OpenGL ES 3.0 bindings.
     const copy_gles = b.addWriteFiles();
-    copy_gles.addCopyFileToSource(@import("zigglgen").generateBindingsSourceFile(b, .{
+    _ = copy_gles.addCopyFile(@import("zigglgen").generateBindingsSourceFile(b, .{
         .api = .gles,
         .version = .@"3.0",
         .extensions = &.{ .EXT_clip_control, .NV_scissor_exclusive },

--- a/zigglgen-example/build.zig.zon
+++ b/zigglgen-example/build.zig.zon
@@ -7,8 +7,7 @@
             .hash = "1220a72c54b4a3674a1e5a907ac6ea33d1868681f187f5a07f3cfb562ff7cf2c63e0",
         },
         .zigglgen = .{
-            .url = "https://github.com/castholm/zigglgen/releases/download/v0.2.3/zigglgen.tar.gz",
-            .hash = "1220f4188a5e1bdbb15fd50e9ea322c0721384eeba9bc077e4179b0b0eeaa7fe4ad9",
+            .path = "../zigglgen",
         },
     },
     .paths = .{

--- a/zigglgen-example/build.zig.zon
+++ b/zigglgen-example/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "zigglgen-example",
-    .version = "0.0.0",
+    .version = "0.2.3",
     .dependencies = .{
         .@"mach-glfw" = .{
             .url = "https://pkg.machengine.org/mach-glfw/42fe7ee494d36bee8a82c1563c291d8314a41823.tar.gz",

--- a/zigglgen-example/main.zig
+++ b/zigglgen-example/main.zig
@@ -131,7 +131,7 @@ pub fn main() !void {
     gl.EnableVertexAttribArray(position_attrib);
     gl.VertexAttribPointer(
         position_attrib,
-        @typeInfo(@TypeOf(@as(Vertex, undefined).position)).Array.len,
+        @typeInfo(@TypeOf(@as(Vertex, undefined).position)).array.len,
         gl.FLOAT,
         gl.FALSE,
         @sizeOf(Vertex),
@@ -142,7 +142,7 @@ pub fn main() !void {
     gl.EnableVertexAttribArray(color_attrib);
     gl.VertexAttribPointer(
         color_attrib,
-        @typeInfo(@TypeOf(@as(Vertex, undefined).color)).Array.len,
+        @typeInfo(@TypeOf(@as(Vertex, undefined).color)).array.len,
         gl.FLOAT,
         gl.FALSE,
         @sizeOf(Vertex),

--- a/zigglgen/build.zig
+++ b/zigglgen/build.zig
@@ -51,7 +51,7 @@ pub fn generateBindingsSourceFile(b: *std.Build, options: GeneratorOptions) std.
 fn thisDependency(b: *std.Build, args: anytype) *std.Build.Dependency {
     find_dep: {
         const all_pkgs = @import("root").dependencies.packages;
-        const pkg_hash = inline for (@typeInfo(all_pkgs).Struct.decls) |decl| {
+        const pkg_hash = inline for (@typeInfo(all_pkgs).@"struct".decls) |decl| {
             const pkg = @field(all_pkgs, decl.name);
             if (@hasDecl(pkg, "build_zig") and pkg.build_zig == @This()) break decl.name;
         } else break :find_dep;

--- a/zigglgen/build.zig.zon
+++ b/zigglgen/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = "zigglgen",
     .version = "0.2.3",
-    .minimum_zig_version = "0.12.0-dev",
+    .minimum_zig_version = "0.14.0-dev",
     .paths = .{
         "LICENSE.md",
         "README.md",

--- a/zigglgen/generator.zig
+++ b/zigglgen/generator.zig
@@ -60,7 +60,7 @@ const ApiVersionProfile = struct {
         const maybe_raw_profile = raw_it.next();
         if (raw_it.next() != null) return error.UnknownExtraField;
 
-        var api: registry.Api.Name = switch (inline for (@typeInfo(options.Api).Enum.fields) |field| {
+        var api: registry.Api.Name = switch (inline for (@typeInfo(options.Api).@"enum".fields) |field| {
             if (std.mem.eql(u8, raw_api, field.name)) break @field(options.Api, field.name);
         } else return error.InvalidApi) {
             .gl => .gl,
@@ -68,7 +68,7 @@ const ApiVersionProfile = struct {
             .glsc => .glsc2,
         };
 
-        const version: [2]u8 = inline for (@typeInfo(options.Version).Enum.fields) |field| {
+        const version: [2]u8 = inline for (@typeInfo(options.Version).@"enum".fields) |field| {
             if (std.mem.eql(u8, raw_version, field.name)) {
                 const dot = std.mem.indexOfScalar(u8, raw_version, '.').?;
                 break .{
@@ -79,7 +79,7 @@ const ApiVersionProfile = struct {
         } else return error.InvalidVersion;
 
         var maybe_profile: ?registry.ProfileName = if (maybe_raw_profile) |raw_profile|
-            switch (inline for (@typeInfo(options.Profile).Enum.fields) |field| {
+            switch (inline for (@typeInfo(options.Profile).@"enum".fields) |field| {
                 if (std.mem.eql(u8, raw_profile, field.name)) break @field(options.Profile, field.name);
             } else return error.InvalidProfile) {
                 .core => .core,
@@ -149,12 +149,12 @@ fn parseExtension(raw: []const u8, api: registry.Api.Name) ParseExtensionError!r
     // Statically assert that 'generator_options.zig' and 'api_registry.zig' are in sync.
     comptime {
         @setEvalBranchQuota(100_000);
-        for (@typeInfo(options.Extension).Enum.fields, @typeInfo(registry.Extension.Name).Enum.fields) |a, b| {
+        for (@typeInfo(options.Extension).@"enum".fields, @typeInfo(registry.Extension.Name).@"enum".fields) |a, b| {
             std.debug.assert(std.mem.eql(u8, a.name, b.name));
         }
     }
 
-    const extension: registry.Extension.Name = inline for (@typeInfo(registry.Extension.Name).Enum.fields) |field| {
+    const extension: registry.Extension.Name = inline for (@typeInfo(registry.Extension.Name).@"enum".fields) |field| {
         if (std.mem.eql(u8, raw, field.name)) break @field(registry.Extension.Name, field.name);
     } else return error.InvalidExtension;
 


### PR DESCRIPTION
zigglgen does not work with Zig master currently as `std.builtin.Type` and `std.Build` APIs have changed a lot.
This PR updates zigglgen and zigglgen-example so it works again.

Please note that this won't work with mach-glfw as that one is still stuck on its own version.

Closes #8 