### PR TITLE
Add missing non-extension param overrides

### DIFF
--- a/zigglgen.zig
+++ b/zigglgen.zig
@@ -1595,9 +1595,14 @@ fn paramOverride(command: registry.Command.Name, param_index: usize) ?struct { [
             2 => .{ "textures", "[*]uint" },
             else => null,
         },
+        .CreateTransformFeedbacks,
+        => switch (param_index) {
+            1 => .{ "ids", "[*]uint" },
+            else => null,
+        },
         .CreateVertexArrays,
         => switch (param_index) {
-            2 => .{ "arrays", "[*]uint" },
+            1 => .{ "arrays", "[*]uint" },
             else => null,
         },
         .DebugMessageCallback,
@@ -2451,7 +2456,7 @@ fn paramOverride(command: registry.Command.Name, param_index: usize) ?struct { [
         },
         .GetPointerv,
         => switch (param_index) {
-            2 => .{ "params", "*?*anyopaque" },
+            1 => .{ "params", "*?*anyopaque" },
             else => null,
         },
         .GetPolygonStipple,

--- a/zigglgen.zig
+++ b/zigglgen.zig
@@ -1815,6 +1815,11 @@ fn paramOverride(command: registry.Command.Name, param_index: usize) ?struct { [
             1 => .{ "pointer", "usize" },
             else => null,
         },
+        .EdgeFlagv,
+        => switch (param_index) {
+            0 => .{ "flag", "*const boolean" },
+            else => null,
+        },
         .Enable,
         => switch (param_index) {
             0 => .{ "target", "@\"enum\"" },


### PR DESCRIPTION
I noticed that `CreateVertexArrays` had a [*c] parameter, unlike the other `Create*` funcs, so I looked at the repo and saw the section at the end of the README and decided to fix it.

I forked the repo and ran `zig build run -- gl-4.6-compatibility | grep -F [*c]`, which showed the 4 functions in this PR:
- `CreateVertexArrays` and `GetPointerv` had existing overrides but with off-by-one errors :)
- `CreateTransfromFeedbacks` I assume was just overlooked, so I added it analogously to the other Create* funcs
- `EdgeFlagv` - https://registry.khronos.org/OpenGL-Refpages/gl2.1/xhtml/glEdgeFlag.xml says that it accepts "a pointer to an array that contains a single boolean element", so a regular single-item pointer seems aproppriate

Now greping for [*c] shows no matches, so all non-extension functions are c-pointer free

Thanks for the amazing project!